### PR TITLE
Fixes author page Jam links from throwing 404

### DIFF
--- a/lib/queries/jams.js
+++ b/lib/queries/jams.js
@@ -124,6 +124,9 @@ const getJamsByAuthorId = gql`
         title
       }
       author {
+        slug {
+          current
+        }
         name
         image {
           asset {


### PR DESCRIPTION
The author links on the author page jams are throwing a 404.

The URL slug is undefined as its not available on the query.

This simply adds the author slug to the `PostsByAuthor` query to make that data available.

Note: arguably we could / should remove the link from the jams on the author page, as it self-links, but considered that a bit out of scope from fixing the bug.

Fixes #223 