### PR TITLE
Search query operators for improved topic matching

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -67,20 +67,34 @@ export default function Dashboard() {
 
       const queries = {
         $or: [
-          { title: searchValue },
+          {
+            title: searchValue,
+          },
           {
             $path: ['author.name'],
             $val: searchValue,
           },
           {
-            $and:
-              formattedTags.length > 0
-                ? [{ $path: 'tags.title', $val: formattedTags[0] }]
-                : [],
+            $path: ['tags.title'],
+            $val: searchValue,
           },
         ],
+        $and: [],
       };
+
+      // Add an $and with the tag title if we have an active topic
+
+      if (formattedTags.length > 0) {
+        formattedTags.forEach((tag) => {
+          queries.$and.push({
+            $path: 'tags.title',
+            $val: `'${tag}`, // the ' in front adds exact match
+          });
+        });
+      }
+
       const results = fuse.search(queries).map((result) => result.item);
+
       handleFilter(results);
       // routerPushTags({ tags: selectedFilters.map((f) => f.title).join(',') });
     }


### PR DESCRIPTION
This updates the search query to do a few things:
* If a topic is selected, it uses that as a required ($and) exact match search
* It now loops through the selected tags, so selecting multiple tags filters down as expected
* Adds `tag.title` to the $or operator to show results that may fuzzy match the various topics

Future thought: I'm thinking we might see better performance if this logic and general search results filtering were to be performed within the React render cycle as opposed to storing all of the results in state as it is happening now. Created https://github.com/mediadevelopers/media-jams/issues/235 to explore

Fixes https://github.com/mediadevelopers/media-jams/issues/221