### PR TITLE
Fixes Featured Jam bookmarking

### DIFF
--- a/lib/queries/jams.js
+++ b/lib/queries/jams.js
@@ -83,6 +83,7 @@ const getFeaturedJams = gql`
   {
     jams: allPost(where: { postMetadata: { featured: { eq: true } } }) {
       id: _id
+      _id
       publishedAt
       author {
         name


### PR DESCRIPTION
Featured Jams currently aren't working for bookmarks, this is due to the `_id` field being renamed to `id` which bookmarking expects the `_id`.

This simply re-adds `_id` to the query, but didn't remove `id` to avoid any breakage

Fixes https://github.com/mediadevelopers/media-jams/issues/245