### PR TITLE
Get related jams by first tag title

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -33,7 +33,7 @@ const postWorkflowByID = groq`
   }[0]
   `;
 
-const postFields = `
+const postFields = groq`
 _id,
 title,
 "slug": slug.current,
@@ -54,32 +54,37 @@ body,
 "tags": tags[]-> title,
 "coverImage": cover.asset->url
 `;
-const postSlugsQuery = `*[_type == "post"]{_id, "slug": slug.current}`;
+const postSlugsQuery = groq`*[_type == "post"]{_id, "slug": slug.current}`;
 const singlePostBySlug = groq`*[_type == "post" && slug.current == $slug] {${postFields}}`;
 const singleDraftPostBySlug = groq`*[_type == "post" && slug.current == $slug && (_id in path("drafts.**"))] {${postFields}}`;
 
 const postsQuery = groq`*[_type == "post"] {${postFields}}`;
 
-const categoriesQuery = `*[_type == "category" ] {
+const categoriesQuery = groq`*[_type == "category" ] {
   title,
   _id,
   "tags": *[ _type == "tag" && references(^._id) ]{ title, _id, featured, rank }
 }`;
 
-const tagsByCategoryId = `*[_type == "tag" && category[]._ref == $categoryId]{
+const tagsByCategoryId = groq`*[_type == "tag" && category[]._ref == $categoryId]{
   title,
   _id,
 }`;
 
-const tagQuery = `*[_type == "tag"] {
+const tagQuery = groq`*[_type == "tag"] {
   title, _id, featured, rank,
   "categories": category[]->{_id,  title}
+}`;
+
+const jamsByTag = groq`*[_type == "tag" && title == $title]{
+  title,
+  "jams": *[_type == "post" && references(^._id) && !(_id in path('drafts.**'))]._id
 }`;
 
 /**
  * Query will ONLY return draft post by specfic _id
  */
-export const queryDraftPostBody = `*[_type == "post" && _id == $postId && (_id in path("drafts.**"))].body`;
+export const queryDraftPostBody = groq`*[_type == "post" && _id == $postId && (_id in path("drafts.**"))].body`;
 /**
  * Uses a read-only token to make fetch requests
  * to Sanity for rendering drafts before they are published publicly
@@ -126,6 +131,16 @@ export async function allPosts() {
 export async function allTags(preview = false) {
   const data = await client.fetch(tagQuery);
   return data;
+}
+
+/**
+ * Get Jams by tag title that are published.
+ * @param {String} title tag title
+ * @returns results[] w/ jam
+ */
+export async function postsByTag(title, n = 3) {
+  const data = await client.fetch(jamsByTag, { title });
+  return data[0].jams.sort(() => Math.random() - Math.random()).slice(0, n);
 }
 
 /**

--- a/pages/post/[slug].js
+++ b/pages/post/[slug].js
@@ -8,6 +8,7 @@ import { NextSeo } from 'next-seo';
 import { postBySlug, postsWithSlug } from '@lib/api';
 import { useMixPanel } from '@lib/mixpanel';
 import { useOnRead } from '@hooks/useOnRead';
+import { useRelatedJams } from '@hooks/useJams';
 
 import { Flex } from '@chakra-ui/react';
 import Layout from '@components/Layout';
@@ -22,6 +23,7 @@ export default function Post({ post, preview, error, og }) {
   const mixpanel = useMixPanel();
   const mainContentRef = React.useRef(null);
   const router = useRouter();
+  const { data, isLoading } = useRelatedJams(post.tags);
   if (error || (!router.isFallback && !post?.slug)) {
     return <ErrorPage statusCode={404} />;
   }
@@ -105,6 +107,7 @@ export default function Post({ post, preview, error, og }) {
           </JamContent>
         </main>
         <JamAuthorBanner author={author}></JamAuthorBanner>
+
         <EmailSubscription />
       </Flex>
     </>

--- a/pages/post/[slug].js
+++ b/pages/post/[slug].js
@@ -23,7 +23,7 @@ export default function Post({ post, preview, error, og }) {
   const mixpanel = useMixPanel();
   const mainContentRef = React.useRef(null);
   const router = useRouter();
-  const { data, isLoading } = useRelatedJams(post.tags);
+  const { data, isLoading } = useRelatedJams(post?.tags);
   if (error || (!router.isFallback && !post?.slug)) {
     return <ErrorPage statusCode={404} />;
   }

--- a/src/hooks/useJams.js
+++ b/src/hooks/useJams.js
@@ -1,4 +1,5 @@
 import { useQueryClient, useQuery, useMutation } from 'react-query';
+import { postsByTag } from '@lib/api';
 import { jams as queryJams } from '@lib/queries/jams';
 
 export function useJamsQuery(select, options) {
@@ -22,5 +23,26 @@ export const useJamQueryBy = (ids) => {
     }),
   );
 };
+
+/**
+ *
+ * @param {Array<string>} tags
+ * @param {*} options
+ * @returns query object data of related jams by tag title
+ */
+export async function useRelatedJams(tags, options) {
+  return useQuery(
+    ['jamTag', tags[0]],
+    async () => {
+      const jamIds = await postsByTag(tags[0]);
+      const data = queryJams.getByIds(jamIds);
+      return data;
+    },
+    {
+      staleTime: Infinity,
+      ...options,
+    },
+  );
+}
 
 export function useJamsMutation() {}

--- a/src/hooks/useJams.js
+++ b/src/hooks/useJams.js
@@ -31,6 +31,7 @@ export const useJamQueryBy = (ids) => {
  * @returns query object data of related jams by tag title
  */
 export async function useRelatedJams(tags, options) {
+  if (tags === undefined) return { data: null };
   return useQuery(
     ['jamTag', tags[0]],
     async () => {


### PR DESCRIPTION
Related Jams are now available on any particular Jam Page `/pages/[slug].js`

using `const { data, isLoading } = useRelatedJams(post.tags);` to pass that specific jams tags, it will return Jam data of 3 related, yet randomly selected. So anytime you visit that page, you _should_ see related by tag, but different jams to an extent. 