### PR TITLE
Remove new note button on bookmarks panel

### DIFF
--- a/src/components/Sidebar/SideContent/NotesPanel.js
+++ b/src/components/Sidebar/SideContent/NotesPanel.js
@@ -55,7 +55,7 @@ const EmptyNotes = ({ user }) => {
       {user ? (
         <>
           <Box size="xs">
-            <Image src="/emptyBookmarks.svg" alt="bookmarks empty" />
+            <Image src="/emptyNotes.svg" alt="notes empty" />
           </Box>
           <Heading size="H200" color="primary.900">
             You don't have any notes

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -148,9 +148,11 @@ const SideStrip = () => {
   );
 };
 
-const SideTopBar = ({ onClose, onToggle }) => {
+const SideTopBar = ({ activeTab, onClose, onToggle }) => {
   const { user, isLoading: loadingUser } = useUser();
   const { isOpen, onOpen, onClose: onCloseModal } = useDisclosure();
+
+  const isNotesTab = activeTab === TABS.NOTES.value;
 
   return (
     <Flex w="100%" h="64px">
@@ -167,7 +169,7 @@ const SideTopBar = ({ onClose, onToggle }) => {
       <Spacer />
       {!loadingUser && (
         <HStack spacing={3} px={4} minH="64px">
-          {user ? (
+          {user && isNotesTab && (
             <Button
               onClick={onOpen}
               leftIcon={<Plus />}
@@ -176,7 +178,8 @@ const SideTopBar = ({ onClose, onToggle }) => {
             >
               New Note
             </Button>
-          ) : (
+          )}
+          {!user && (
             <>
               <NextLink href="/api/auth/login">
                 <Button size="md" variant="ghost" color="primary.500">
@@ -202,7 +205,7 @@ const SidebarContent = () => {
   const { Content } = TABS[activeTab];
   return (
     <Flex direction="column" h="100vh" w={{ base: '430px' }}>
-      <SideTopBar onClose={onClose} />
+      <SideTopBar activeTab={activeTab} onClose={onClose} />
       <Content user={user} />
     </Flex>
   );


### PR DESCRIPTION
Sets up the contexts in the component to remove the New Note button in the Bookmarks panel

Additionally updates the image on the Notes panel to the right Notes empty image

Fixes https://github.com/mediadevelopers/media-jams/issues/244