### PR TITLE
Update auth0 links to non-Next.js links

### DIFF
--- a/src/components/Banner/SignupButton.js
+++ b/src/components/Banner/SignupButton.js
@@ -1,14 +1,17 @@
-import NextLink from 'next/link';
-import { Button, Link, Text } from '@chakra-ui/react';
+import { Button, Text } from '@chakra-ui/react';
 
 export default function SignupButton() {
   return (
-    <Link as={NextLink} href="/api/auth/signup">
-      <Button p="6px 32px" borderRadius="8px" bg="primary.500">
-        <Text variant="B400" color="#FFFFFF" fontWeight="700">
-          Sign Up
-        </Text>
-      </Button>
-    </Link>
+    <Button
+      as="a"
+      href="/api/auth/signup"
+      p="6px 32px"
+      borderRadius="8px"
+      bg="primary.500"
+    >
+      <Text variant="B400" color="#FFFFFF" fontWeight="700">
+        Sign Up
+      </Text>
+    </Button>
   );
 }

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -123,7 +123,7 @@ const SideStrip = () => {
               name={user?.name}
               src={user?.picture}
             />
-            <NextLink href="/api/auth/logout">
+            <a href="/api/auth/logout">
               <IconButton
                 size="lg"
                 color="grey.700"
@@ -131,7 +131,7 @@ const SideStrip = () => {
                 aria-label="Logout"
                 icon={<FiLogOut />}
               />
-            </NextLink>
+            </a>
           </>
         )}
         <IconButton
@@ -181,16 +181,23 @@ const SideTopBar = ({ activeTab, onClose, onToggle }) => {
           )}
           {!user && (
             <>
-              <NextLink href="/api/auth/login">
-                <Button size="md" variant="ghost" color="primary.500">
-                  Login
-                </Button>
-              </NextLink>
-              <NextLink href="/api/auth/signup">
-                <Button size="md" colorScheme="primary">
-                  Sign Up
-                </Button>
-              </NextLink>
+              <Button
+                as="a"
+                href="/api/auth/login"
+                size="md"
+                variant="ghost"
+                color="primary.500"
+              >
+                Login
+              </Button>
+              <Button
+                as="a"
+                href="/api/auth/signup"
+                size="md"
+                colorScheme="primary"
+              >
+                Sign Up
+              </Button>
             </>
           )}
         </HStack>


### PR DESCRIPTION
Currently there's an issue with clicking some login or auth-related links.

Appears the issue is due to using the Next.js Link component instead of the traditional anchor tag per https://github.com/auth0/nextjs-auth0/issues/520

This updates the buttons that I was able to find that uses NextLink.

Fixes https://github.com/mediadevelopers/media-jams/issues/243