### PR TITLE
Clear search state on logo click

### DIFF
--- a/src/components/SearchProvider/index.js
+++ b/src/components/SearchProvider/index.js
@@ -6,6 +6,7 @@ export const SSACTIONS = {
   REMOVE_TAG_FILTERS: 'removeTagFilters',
   CLEAR_TAG_FILTERS: 'clearTagFilters',
   SET_JAMS: 'setJams',
+  CLEAR_SEARCH: 'clearSearch',
 };
 
 const initState = {
@@ -39,6 +40,8 @@ function reducer(state, action) {
         ...state,
         selectedTagFilters: [],
       };
+    case SSACTIONS.CLEAR_SEARCH:
+      return initState;
 
     default:
       throw new Error();
@@ -67,6 +70,9 @@ export function SearchProvider({ children }) {
 
     clearAllTags: () => {
       dispatch({ type: SSACTIONS.CLEAR_TAG_FILTERS });
+    },
+    clearSearch: () => {
+      dispatch({ type: SSACTIONS.CLEAR_SEARCH });
     },
   };
   return (

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -23,6 +23,7 @@ const { CREATE_NOTE } = NOTE_ACTIONS;
 import { SideToggle, JoinDiscord, Plus, BWLogo } from '@components/Icons';
 
 import { useSidePanel, TABS } from '@components/SidePanelProvider';
+import { useSearch } from '@components/SearchProvider';
 import { useUser } from '@auth0/nextjs-auth0';
 
 import { FiLogOut } from 'react-icons/fi';
@@ -72,27 +73,32 @@ const SideStrip = () => {
   const displaySideStripLogo = useBreakpointValue({ base: false, md: true });
   const { user, isLoading: loadingUser } = useUser();
   const { onToggle, setActiveTab, activeTab } = useSidePanel();
+  const { clearSearch } = useSearch();
   // onClick set nav.ActiveTab to name
   const handleOnClick = (e) => {
     setActiveTab(e.target.value);
+  };
+  const handleOnLogoClick = (e) => {
+    clearSearch();
   };
   const { AUTHORS, MORE, BOOKMARKS, NOTES } = TABS;
   const sideNavTabs = [AUTHORS, BOOKMARKS, NOTES, MORE];
   return (
     <VStack w="80px" h={{ base: '100%', md: '100vh' }} bg="#E2E2FE">
-      <Link
-        as={NextLink}
-        href="/"
-        display={displaySideStripLogo ? 'auto' : 'none'}
-      >
-        <IconButton
-          size="lg"
-          variant="unstyled"
-          aria-label="Logo"
-          icon={<BWLogo />}
-          display={{ base: 'none', md: 'inline-flex' }}
-        />
-      </Link>
+      <NextLink href="/" passHref>
+        <Link
+          display={displaySideStripLogo ? 'auto' : 'none'}
+          onClick={handleOnLogoClick}
+        >
+          <IconButton
+            size="lg"
+            variant="unstyled"
+            aria-label="Logo"
+            icon={<BWLogo />}
+            display={{ base: 'none', md: 'inline-flex' }}
+          />
+        </Link>
+      </NextLink>
       <VStack spacing={{ base: '48px', md: 6 }}>
         {sideNavTabs.map(({ value, displayName, Icon }) => (
           <SideNavButtonIcon


### PR DESCRIPTION
When the logo is clicked in the sidebar, the search state will refresh

This will provide a similar experience to a traditional website which would reload the homepage if on the homepage and clicking the logo.

Fixes https://github.com/mediadevelopers/media-jams/issues/222