### PR TITLE
Set up Cloudinary transformation and delivery

### DIFF
--- a/src/components/AuthorBanner/MobileAuthorBanner.js
+++ b/src/components/AuthorBanner/MobileAuthorBanner.js
@@ -37,7 +37,7 @@ export default function MobileAuthorBanner({ author }) {
               width="96px"
               height={{ base: '96px', lg: '132px' }}
               name={author.name}
-              src={imageFetch(author.image?.asset.url)}
+              src={imageFetch(author.image?.asset.url, { w: 64, h: 64 })}
               border="1px solid #88B1FC"
               showBorder
               mt={{ base: '8px' }}

--- a/src/components/JamAuthorBanner.js
+++ b/src/components/JamAuthorBanner.js
@@ -28,7 +28,7 @@ function JamAuthorBanner({ author }) {
             <Avatar
               size="2xl"
               alt={author.name}
-              src={imageFetch(author.image?.asset.url)}
+              src={imageFetch(author.image?.asset.url, { w: 64, h: 64 })}
             />
             <VStack spacing="0" pt={4}>
               <Heading mt={4} fontSize="4xl" textStyle="headline-accent">

--- a/src/components/JamCard/JamCard.js
+++ b/src/components/JamCard/JamCard.js
@@ -23,32 +23,38 @@ import {
   useAddBookmarkMutation,
   useRemoveBookmarkMutation,
 } from '@hooks/useBookmarks';
+import imageFetch from '@utils/image-fetch';
 
 import ReactIcon from '@components/ReactIcon';
 
 const DEFAULT_TAGS_TO_SHOW = 3;
 
-const sizes = {
+const jamCardSizes = {
   large: {
     width: 1130,
     height: 330,
   },
   small: {
-    width: 540,
-    height: 330,
+    width: 1640,
+    height: 1002,
   },
+};
+
+const authorAvatarSize = {
+  width: 500,
+  height: 500,
 };
 
 const JamCard = ({ jam, size: sizeKey = 'small' }) => {
   const { author, cover } = jam;
   const isFeatured = jam.postMetadata.featured;
 
-  const [background, setBackground] = useState('');
+  const [images, setImages] = useState();
 
   const firstTags = jam.tags.slice(0, DEFAULT_TAGS_TO_SHOW);
   const remainingTags = jam.tags.slice(DEFAULT_TAGS_TO_SHOW);
 
-  const size = sizes[sizeKey];
+  const size = jamCardSizes[sizeKey];
 
   const {
     data: bookmarksData = {},
@@ -78,7 +84,10 @@ const JamCard = ({ jam, size: sizeKey = 'small' }) => {
 
   useEffect(() => {
     if (!inView) return;
-    setBackground(cover?.asset?.url);
+    setImages({
+      background: cover?.asset?.url,
+      author: author?.image?.asset?.url,
+    });
   }, [inView]);
 
   /**
@@ -107,16 +116,6 @@ const JamCard = ({ jam, size: sizeKey = 'small' }) => {
       borderRadius="4"
       backgroundColor="#6347e2"
     >
-      {/* {cover && (
-        <Image
-          position="absolute"
-          top="0"
-          left="0"
-          zIndex="0"
-          width="100%"
-          src={cover.asset.url}
-        />
-      )} */}
       <Box position="absolute" top="6" right="6" zIndex="2">
         <IconButton
           color="white"
@@ -155,7 +154,10 @@ const JamCard = ({ jam, size: sizeKey = 'small' }) => {
           left="0"
           width="100%"
           height="100%"
-          backgroundImage={background}
+          backgroundImage={
+            images?.background &&
+            imageFetch(images.background, { w: size.width, h: size.height })
+          }
           backgroundSize="cover"
           backgroundPosition="center center"
         >
@@ -309,7 +311,13 @@ const JamCard = ({ jam, size: sizeKey = 'small' }) => {
                 <Avatar
                   size="md"
                   name={author.name}
-                  src={author.image.asset.url}
+                  src={
+                    images?.author &&
+                    imageFetch(images.author, {
+                      w: authorAvatarSize.width,
+                      h: authorAvatarSize.height,
+                    })
+                  }
                   mr="4"
                 />
                 <Flex direction="column" justifyContent="center">

--- a/src/components/JamContentHero.js
+++ b/src/components/JamContentHero.js
@@ -61,7 +61,7 @@ export default function JamContentHero({
         <HStack color="grey.700" ml={{ base: '0', lg: 8 }}>
           <Avatar
             name={author.name}
-            src={imageFetch(author?.image?.asset?.url)}
+            src={imageFetch(author?.image?.asset?.url, { w: 64, h: 64 })}
           />
           <Text fontSize="md">{author.name}</Text>
           <Text fontSize="md">

--- a/src/components/JamList/FeaturedJamCard.js
+++ b/src/components/JamList/FeaturedJamCard.js
@@ -86,7 +86,7 @@ export default function FeaturedJamCard({ jam }) {
               width="28px"
               height="28px"
               name={jam?.author.name}
-              src={imageFetch(jam?.author.image?.asset.url)}
+              src={imageFetch(jam?.author.image?.asset.url, { w: 64, h: 64 })}
             />
             <NextLink href={`/author/${jam?.author.slug?.current}`} passHref>
               <Link>

--- a/src/components/JamList/FeaturedJamList.js
+++ b/src/components/JamList/FeaturedJamList.js
@@ -89,7 +89,7 @@ function JamListCard({ jam }) {
             width="28px"
             height="28px"
             name={jam?.author.name}
-            src={imageFetch(jam?.author.image?.asset.url)}
+            src={imageFetch(jam?.author.image?.asset.url, { w: 64, h: 64 })}
           />
           <NextLink href={`/author/${jam?.author.slug?.current}`} passHref>
             <Link>

--- a/src/components/JamList/JamCard.js
+++ b/src/components/JamList/JamCard.js
@@ -79,7 +79,7 @@ export default function JamCard({ jam }) {
                 <Avatar
                   size="sm"
                   name={author.name}
-                  src={imageFetch(author.image?.asset.url)}
+                  src={imageFetch(author.image?.asset.url, { w: 64, h: 64 })}
                 />
                 <Text variant="B100" color="grey.800" fontWeight="500">
                   {author.name}

--- a/src/components/JamList/MobileFeaturedJamCard.js
+++ b/src/components/JamList/MobileFeaturedJamCard.js
@@ -91,7 +91,7 @@ export default function MobileFeaturedJamCard({ jam }) {
               width="28px"
               height="28px"
               name={author.name}
-              src={imageFetch(author.image?.asset.url)}
+              src={imageFetch(author.image?.asset.url, { w: 64, h: 64 })}
             />
             <NextLink href={`/author/${jam?.author.slug?.current}`} passHref>
               <Link>

--- a/src/components/JamList/MobileJamCard.js
+++ b/src/components/JamList/MobileJamCard.js
@@ -77,7 +77,7 @@ export default function MobileJamCard({ jam }) {
               width="28px"
               height="28px"
               name={jam?.author.name}
-              src={imageFetch(jam?.author.image?.asset.url)}
+              src={imageFetch(jam?.author.image?.asset.url, { w: 64, h: 64 })}
             />
             <NextLink href={`/author/${jam.author.slug?.current}`} passHref>
               <Link>

--- a/src/components/Sidebar/SideContent/AuthorsPanel.js
+++ b/src/components/Sidebar/SideContent/AuthorsPanel.js
@@ -56,7 +56,10 @@ export const AuthorCard = ({ author, ...props }) => {
       {...props}
     >
       <Flex direction="row" spacing={{ base: '1', md: '2' }}>
-        <Avatar name={author.name} src={imageFetch(author.image?.asset.url)} />
+        <Avatar
+          name={author.name}
+          src={imageFetch(author.image?.asset.url, { w: 64, h: 64 })}
+        />
         <VStack alignItems="flex-start" ml="2">
           <LinkOverlay href={`/author/${author.slug?.current}`}>
             <Heading as="h5" size="H100">

--- a/src/components/Sidebar/SideContent/BookmarksPanel.js
+++ b/src/components/Sidebar/SideContent/BookmarksPanel.js
@@ -134,7 +134,7 @@ export const BookmarkJamCard = ({ jam, ...props }) => {
             width="20px"
             height="20px"
             name={author.name}
-            src={imageFetch(author.image?.asset.url)}
+            src={imageFetch(author.image?.asset.url, { w: 64, h: 64 })}
           />
           <NextLink href={`/author/${author.slug?.current}`} passHref>
             <Link>

--- a/src/components/TagCard/TagCard.js
+++ b/src/components/TagCard/TagCard.js
@@ -1,6 +1,8 @@
 import NextLink from 'next/link';
 import { Flex, Box, Text, Link } from '@chakra-ui/react';
 
+import imageFetch from '@utils/image-fetch';
+
 import ReactIcon from '@components/ReactIcon';
 
 const TagCardContent = ({ tag, onClick, ...rest }) => {
@@ -26,7 +28,7 @@ const TagCardContent = ({ tag, onClick, ...rest }) => {
       _hover={{
         textDecoration: 'none',
       }}
-      backgroundImage={image.url}
+      backgroundImage={image.url && imageFetch(image.url, { w: 1640 })}
       backgroundSize="cover"
       backgroundPosition="center center"
       backgroundColor="#1B1464"

--- a/src/utils/image-fetch.js
+++ b/src/utils/image-fetch.js
@@ -1,11 +1,34 @@
 import { useImage } from 'use-cloudinary';
 
-const defaultOptions = { w: 64, h: 64 };
-
-function ImageFetch(src, options = defaultOptions) {
+function ImageFetch(src, options = {}) {
   const { generateImageUrl } = useImage('mediadevs');
 
-  const { w = 64, h = 64 } = options;
+  const { w, h } = options;
+
+  const transformation = [
+    {
+      format: 'auto',
+      quality: 'auto',
+    },
+  ];
+
+  if (w || h) {
+    const size = {};
+
+    if (w) {
+      size.width = w;
+    }
+
+    if (h) {
+      size.height = h;
+    }
+
+    transformation.push({
+      crop: 'fill',
+      ...size,
+    });
+  }
+
   return !src
     ? undefined
     : generateImageUrl({
@@ -13,13 +36,7 @@ function ImageFetch(src, options = defaultOptions) {
           publicId: src,
           storageType: 'fetch',
         },
-        transformation: [
-          {
-            crop: 'fill',
-            width: w,
-            height: h,
-          },
-        ],
+        transformation,
       });
 }
 


### PR DESCRIPTION
Updates the images being used in the new experience to be sourced from Cloudinary

In order to use the fetch function I needed to remove the default size object so I could simply get a cloudinary URL without specific transformations.

Fixes https://github.com/mediadevelopers/media-jams/issues/266