### PR TITLE
Add new documents to schema items

### DIFF
--- a/studio/app/structure/creator.js
+++ b/studio/app/structure/creator.js
@@ -30,6 +30,9 @@ export const creatorListItems = [
         .title('Jams')
         .filter(AUTHOR_QUERY)
         .params({ type: 'post', authorId: self })
+        .initialValueTemplates([
+          S.initialValueTemplateItem('post-by-author', { authorId: self }),
+        ])
         .child((documentId) => jamView(documentId));
     },
   }),

--- a/studio/app/structure/initialValueTemplates.js
+++ b/studio/app/structure/initialValueTemplates.js
@@ -6,7 +6,8 @@ import T from '@sanity/base/initial-value-template-builder';
 import userStore from 'part:@sanity/base/user';
 
 const postByAuthor = {
-  title: 'Post by author',
+  title: 'Post by Author',
+  id: 'post-by-author',
   description: 'Post by a specific author',
   schemaType: 'post',
   name: 'post-by-author',
@@ -27,9 +28,5 @@ const postByAuthor = {
   },
 };
 
-export default [
-  T.template({
-    id: 'post-by-author',
-    ...postByAuthor,
-  }),
-];
+const defaults = T.defaults();
+export default [T.template(postByAuthor), ...defaults];

--- a/studio/app/structure/initialValueTemplates.js
+++ b/studio/app/structure/initialValueTemplates.js
@@ -28,5 +28,4 @@ const postByAuthor = {
   },
 };
 
-const defaults = T.defaults();
-export default [T.template(postByAuthor), ...defaults];
+export default [T.template(postByAuthor), ...T.defaults()];


### PR DESCRIPTION
Seems no default initial templates were added back when I created the 'Post-by-Author' template. 

## But now they are back!
<img width="1819" alt="CleanShot 2022-06-08 at 15 59 34@2x" src="https://user-images.githubusercontent.com/76360/172731560-d268c596-1746-4077-8ca0-f65ca5017a71.png">

## Moderators will see both templates, but Jams shouldn't be created here, rather under 'My Jams'. I didn't see a way to override the default scheme template, or even filter it out. 🤔
![CleanShot 2022-06-08 at 15 57 14@2x](https://user-images.githubusercontent.com/76360/172731584-bbb5821d-7195-4502-b722-c9c7af0069cd.png)

## Creators will continue to get the 'By Author' template
<img width="1911" alt="CleanShot 2022-06-08 at 15 56 08@2x" src="https://user-images.githubusercontent.com/76360/172731722-3e25f344-0a90-4baf-a25d-6028d61371b7.png">


