### PR TITLE
fix redirects that use `.` in their path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,14 @@
    - Using a Custom MDX component in the Jam Content it's rendered as an iFrame with specific attributes.
      - Including using MirrorCode and 'click to load' to help reduce the time to interact
      - Options include having a specific file and | or preview panel open.
+
+## Redirects
+
+Redirects are managed via the [Next.js Config Redirects feature](https://nextjs.org/docs/api-reference/next.config.js/redirects).
+
+- `/post/:slug` paths are directed to `https://cloudinary.com/blog/guest_post/:slug`
+  - Special identified routes are remapped as needed, i.e. `.` is replaced with `-` on a special set of slugs
+  - The redirect is temporary for now because the eventual target URI will be `https://cloudinary.com/blog/:slug`
+- `/author/:path` paths are directed to `https://cloudinary.com/blog/author/:path` using a permanent redirect
+- `/` is redirected to `https://cloudinary.com/blog`
+- All doc routes are redirected to `https://cloudinary.com`

--- a/next.config.js
+++ b/next.config.js
@@ -60,7 +60,20 @@ const defaultConfig = {
     ];
   },
   async redirects() {
+    const customPeriodRewrites = [
+      '/post/create-a-restaurant-qr-code-menu-in-next.js',
+      '/post/blur-faces-in-images-in-next.js',
+      "/post/create-a-youtube-like-'click-to-unmute'-feature-in-nuxt.js",
+      '/post/create-a-contact-card-barcode-generator-in-next.js',
+      '/post/create-custom-video-ads-with-text-and-image-in-next.js',
+    ];
+
     return [
+      ...customPeriodRewrites.map((path) => ({
+        source: `${path}(.*)`,
+        destination: path.replace(/\./g, '-'),
+        permanent: false,
+      })),
       {
         source: '/post/:path*',
         destination: 'https://cloudinary.com/blog/guest_post/:path*',
@@ -72,13 +85,13 @@ const defaultConfig = {
         permanent: true,
       },
       {
-        source: '/docs',
-        destination: '/docs/getting-started/installation',
+        source: '/',
+        destination: 'https://cloudinary.com/blog',
         permanent: true,
       },
       {
-        source: '/',
-        destination: 'https://cloudinary.com/blog',
+        source: '/docs/:path*',
+        destination: 'https://cloudinary.com',
         permanent: true,
       },
     ];

--- a/studio/README.md
+++ b/studio/README.md
@@ -51,8 +51,23 @@ General workflow is from 'jam creation' -> 'in review' -> 'approved' -> 'publish
 
 Exporting data can be achieved with the following guidelines.
 
-1. Install the Sanity CLI
-1. Login to the Sanity CLI
+### Pre-requisites
+
+- Sanity CLI
+
+```
+npm install -g @sanity/cli
+sanity login
+```
+
+- jq
+
+```
+brew install jq
+```
+
+### Steps
+
 1. execute `sh ./scripts jsonPostOutpush.sh`
 1. A `.json` and `.csv` will not be in the studio directory. This includes all published posts and meta data for each format.
 1. If a copy of the raw markdown is needed again. The json output can be run through the `wpConvertData.js` and it will transform the body of each post into a separate markdown file.

--- a/studio/scripts/jsonPostOutput.sh
+++ b/studio/scripts/jsonPostOutput.sh
@@ -5,10 +5,8 @@ timestamp() {
   date "+%Y.%m.%d-%H.%M.%S" # current time
 }
 
-
 sanity documents query --api-version v2021-06-07 '*[_type == "post" && !(_id in path("drafts.**"))]{
    "id": _id, title,description, "tags": tags[]-> {title}, "url_title": slug.current,"created_at":_createdAt, "published_at":publishedAt, "updated_at": _updatedAt, "image_url": cover.asset->url, "content": body , "author": author->name, "author_title" : author->jobTitle, "author_image_url": author->image.asset->url, "author_twitter" : author->socialHandles.twitter, "author_github" : author->socialHandles.github, "author_linkedin" : author->socialHandles.linkedin, "author_bio" : author->bio[0].children[0].text
-    }'  --dataset production --pretty | tee "posts_$(timestamp).json" |  jq -r '(map(keys) | add | unique) as $cols 
-| map(. as $row | $cols | map($row[.]  | if type=="array" then map(. | select(.title) | ."title") | join(",")  else . end)) as $rows 
+    }'  --dataset production --pretty | tee "posts_$(timestamp).json" |  jq -r '(map(keys) | add | unique) as $cols
+| map(. as $row | $cols | map($row[.]  | if type=="array" then map(. | select(.title) | ."title") | join(",")  else . end)) as $rows
 | $cols, $rows[] | @csv' | tee "posts_$(timestamp).csv"
-    


### PR DESCRIPTION
# Background

The new system we're redirecting to cannot handle `.` in the slugs. We need to remap the `.` to `-` in the following slugs and map those redirects. We also need to map all the doc routes to the main Cloudinary homepage.

```
https://mediajams.dev/post/create-a-restaurant-qr-code-menu-in-next.js.
https://mediajams.dev/post/blur-faces-in-images-in-next.js.
https://mediajams.dev/post/create-a-youtube-like-'click-to-unmute'-feature-in-nuxt.js.
https://mediajams.dev/post/create-a-contact-card-barcode-generator-in-next.js
https://mediajams.dev/post/create-custom-video-ads-with-text-and-image-in-next.js
```

# What was done
- Added details in the README about redirects
- Updated redirects to remap the known set to fix their URIs
- Added some notes to the CSV exporter that were sitting on my system and needed to be captured.